### PR TITLE
default: re-export deploy scripts at the top-level

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -20,4 +20,4 @@ conf: let
       { _module.args.nixusPkgs = nixusPkgs; }
     ];
   };
-in result.config.deployScript // result
+in result.config.deployScript // result // nixusPkgs.lib.mapAttrs (n: v: v.combinedDeployScript) result.config.nodes


### PR DESCRIPTION
This makes it easier to build/deploy individual boxes, allowing you to
`nix-build deployment.nix -A mySystem` as opposed to `nix-build deployment.nix -A config.nodes.mySystem.combinedDeployScript`