### PR TITLE
Create flake.nix

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,29 @@
+{
+  description = "Deployment tool for multiple NixOS systems";
+
+  edition = 201909;
+
+  outputs = { self, nixpkgs }: {
+    lib.nixus = conf: let
+      nixusPkgs = import nixpkgs {
+        config = {};
+        overlays = [
+          (self: super: {
+            lib = super.lib.extend (import ./dag.nix);
+          })
+        ];
+      };
+
+      result = nixusPkgs.lib.evalModules {
+        modules = [
+          modules/options.nix
+          modules/deploy.nix
+          modules/secrets.nix
+          conf
+          # Not naming it pkgs to avoid confusion and trouble for overriding scopes
+          { _module.args.nixusPkgs = nixusPkgs; }
+        ];
+      };
+    in result.config.deployScript // result // nixusPkgs.lib.mapAttrs (n: v: v.deployScript) result.config.nodes;
+  };
+}

--- a/flake.nix
+++ b/flake.nix
@@ -2,6 +2,8 @@
   description = "Deployment tool for multiple NixOS systems";
 
   edition = 201909;
+  
+  inputs.nixpkgs.url = "github:nixos/nixpkgs/3320a06049fc259e87a2bd98f4cd42f15f746b96";
 
   outputs = { self, nixpkgs }: {
     lib.nixus = conf: let


### PR DESCRIPTION
```
00:01:04 bqv:         infinisil: anything against making default.nix an auto-call function rather than hardcoding nixpkgs.nix?
00:01:23 bqv:         or better yet, mind if i just PR in a flake.nix?
00:01:33 bqv:         maybe that's better.
00:04:30 infinisil:   bqv: The hardcoded nixpkgs.nix is kind of by design, as it allows me to guarantee that nixus works independent of what nixpkgs the user uses
00:05:06 infinisil:   Which previously was important because I needed to use a nixpkgs PR of mine with some module changes
00:05:37 infinisil:   Not sure how flake.nix's work yet, haven't looked into it much
00:06:13 bqv:         so it's similar, in that the flake.lock can lock nixpkgs to a certain rev (but also allow people to override that at their own risk)
00:07:45 bqv:         in fact, even without a flake.lock in the repo, you could specify a certain rev of nixpkgs in the flake.nix directly so it's explicit
00:08:34 bqv:         problem i'm hitting now is that even with creating a flake.nix i'd basically have to copy-paste default.nix into it
00:11:31 bqv:         i note your lib conversation above means i can't even elide the nixusPkgs stuff
```