### PR TITLE
Kill all backgrounded process groups instead of querying for session IDs

### DIFF
--- a/modules/deploy.nix
+++ b/modules/deploy.nix
@@ -157,7 +157,7 @@ let
 
         # Kill all child processes when interrupting/exiting
         trap exit INT TERM
-        trap 'ps -s $$ -o pid= | xargs -r -n1 kill' EXIT
+        trap 'for pid in $(jobs -p) ; do kill -- -$pid ; done' EXIT
         # Be sure to use --foreground for all timeouts, therwise a Ctrl-C won't stop them!
         # See https://unix.stackexchange.com/a/233685/214651
 


### PR DESCRIPTION
Fixes #20: Session IDs aren't really working under Darwin, so let's find the PIDs of background processes via `jobs` and kill their whole process group.

With this fix in place, I can run the nixus build result under Darwin & deploy to my machine without receiving an error message at the end.