### PR TITLE
Implement generic privilege escalation support

### DIFF
--- a/modules/options.nix
+++ b/modules/options.nix
@@ -79,6 +79,15 @@ let
         '';
       };
 
+      privilegeEscalationCommand = lib.mkOption {
+        type = types.listOf types.str;
+        default = [ "sudo" ];
+        example = lib.literalExample ''[ "doas" ]'';
+        description = ''
+          The command to use for privilege escalation.
+        '';
+      };
+
     };
 
     config = {

--- a/scripts/switch
+++ b/scripts/switch
@@ -25,7 +25,7 @@ set -u
 
 # This script needs to be run as root
 if [[ "$EUID" -ne 0 ]]; then
-	exec sudo "$0" "$@"
+	exec @privilegeEscalationCommand@ "$0" "$@"
 fi
 
 mkdir -p /var/lib/system-switcher


### PR DESCRIPTION
Instead of hard-coding sudo, the user can now specify what binary should
be used for operations requiring heightened privileges.

---

While I only tested this with `privilegeEscalationCommand = [ "doas" ];`, this should theoretically work for all privilege escalation binaries. Implemented as a list because it looks nicer than just a string (even though they would be identical in the end).

Addresses point 1 of https://github.com/Infinisil/nixus/issues/22#issuecomment-673609412. SSH root logins remain to be implemented.