### PR TITLE
Default host to attribute name

### DIFF
--- a/modules/deploy.nix
+++ b/modules/deploy.nix
@@ -53,6 +53,7 @@ let
       # TODO: What about different ssh ports? Some access abstraction perhaps?
       host = lib.mkOption {
         type = lib.types.nullOr lib.types.str;
+        default = name;
         example = "root@172.18.67.46";
         description = ''
           How to reach the host via ssh. Deploying is disabled if null. The


### PR DESCRIPTION
Allows to omit duplicate `host` attribute
when the node can be reached over SSH via its attribute name.

I usually manage my hosts via `home-manager` and they can be reached via "symbolic" names as defined in `ssh_config` making setting host redundant as it can be just reused from attribute name.

This change makes it behave similar to `morph` and allows me to use just:

```
  nodes.rpi = { lib, config, ... }: {
    configuration = ./rpi_configuration.nix;
  };
```