### PR TITLE
Use `pkgs.runtimeShell` as switch script shell

### DIFF
--- a/modules/deploy.nix
+++ b/modules/deploy.nix
@@ -6,6 +6,7 @@ let
     let
       switch = pkgs.runCommandNoCC "switch" {
         inherit (config) switchTimeout successTimeout ignoreFailingSystemdUnits privilegeEscalationCommand;
+        shell = pkgs.runtimeShell;
       } ''
         mkdir -p $out/bin
         substituteAll ${../scripts/switch} $out/bin/switch


### PR DESCRIPTION
This allows to switch e.g. `aarch64` machine from `x86` host.
Otherwise wrong path is propagated to target. Since `bash`
is already in `systemPackages` this seems safe to do.

It looks like a hack but it allowed me to deploy rPi from `x86` host, marking as draft.