### PR TITLE
Bumped nixpkgs

### DIFF
--- a/example/default.nix
+++ b/example/default.nix
@@ -7,8 +7,8 @@ import ../. {} ({ config, ... }: {
 
     # Which nixpkgs version we want to use for this node
     nixpkgs = fetchTarball {
-      url = "https://github.com/NixOS/nixpkgs/tarball/16fc531784ac226fb268cc59ad573d2746c109c1";
-      sha256 = "0qw1jpdfih9y0dycslapzfp8bl4z7vfg9c7qz176wghwybm4sx0a";
+      url = "https://github.com/NixOS/nixpkgs/tarball/38431cf21c59a84c0ddedccc0cd66540a550ec26";
+      sha256 = "0bi5lkq2a34pij00axsa0l0j43y8688mf41p51b6zyfdzgjgsc42";
     };
   };
 

--- a/nixpkgs.nix
+++ b/nixpkgs.nix
@@ -1,4 +1,4 @@
 fetchTarball {
-  url = "https://github.com/NixOS/nixpkgs/tarball/f211631c1cb3e94828c7650b5d12c1e5a89e0e16";
-  sha256 = "0r085j42991qcbzx4l0hnwlsxw016y4b7r821s4qxvqnvwr9lxar";
+  url = "https://github.com/NixOS/nixpkgs/tarball/38431cf21c59a84c0ddedccc0cd66540a550ec26";
+  sha256 = "0bi5lkq2a34pij00axsa0l0j43y8688mf41p51b6zyfdzgjgsc42";
 }


### PR DESCRIPTION
Got this error

```
error: attribute 'deprecationMessage' missing, at /nix/store/n7knsc9fmc36y3k3xd939dnyy3nfidw4-source/lib/modules.nix:508:12
(use '--show-trace' to show detailed location information)
```

which is related to https://github.com/NixOS/nixpkgs/pull/98952 (thanks @Infinisil) :)

EDIT: bumped both the example nixpkgs and `nixpkgs.nix`