### PR TITLE
WIP nixus.prometheus: module for monitoring using prometheus and wireguard

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -28,6 +28,7 @@ nixusArgs: conf: let
       modules/public-ip.nix
       modules/dns.nix
       modules/vpn
+      modules/prometheus
       conf
       # Not naming it pkgs to avoid confusion and trouble for overriding scopes
       {

--- a/modules/prometheus/default.nix
+++ b/modules/prometheus/default.nix
@@ -1,0 +1,119 @@
+{ config, lib, ... }:
+
+let
+  inherit (lib) types;
+
+  secretsOpts = {
+    # secret files
+    wgPublicKey = lib.mkOption {
+      type = types.path;
+    };
+    wgPrivateKey = lib.mkOption {
+      type = types.path;
+    };
+    wgPresharedKey = lib.mkOption {
+      type = types.path;
+    };
+  };
+
+  nodeOpts = { name, config, ... }: {
+    options = {
+      enable = lib.mkEnableOption "Enable prometheus monitoring for this node";
+
+      name = lib.mkOption {
+        type = types.str;
+        default = name;
+        description = "The name of the name, which is what will be used for prometheus as well";
+      };
+
+      # isIPv6 = lib.mkOption {
+      #   type = types.bool;
+      #   default = false;
+      #   description = ''
+      #     Indicates if the IP is IPv6, if so it will be enclosed in 
+      #   '';
+      # };
+
+      isLocal = lib.mkOption {
+        type = types.bool;
+        default = false;
+        description = ''
+          Indicates of the device is attached to the same network as the prometheus instance
+
+          false indicates that the node is not on the same network, and will then use a wireguard
+          tunnel to connect to the instance.
+
+          true indicates that the node is on the same network, ind will then not use a wireguard
+          tunnel to connect to the instance.
+        '';
+      };
+
+      ip = lib.mkOption {
+        type = types.str;
+        description = ''
+          The IP address of the node, that the prometheus instance should try to contact to scrape.
+          Remember, if this is given as IPv6, it should be encloused in brackets like so, e.g. [fc00:1234::10].
+
+          This is also the IP address that the prometheus exporters will bind to.
+        '';
+      };
+
+      ips = lib.mkOption {
+        type = types.str;
+        description = ''
+          TODO(eyJhb): fix this
+          fc00:1234::10/128
+        '';
+      };
+    } // secretsOpts;
+  };
+
+  primaryNodeOpts = { ... }: {
+    options = {
+      name = lib.mkOption {
+        type = types.str;
+      };
+
+      ip = lib.mkOption {
+        type = types.str;
+        description = "fc00:1234::1/128";
+      };
+    } // secretsOpts;
+  };
+
+  baseOpts = { ... }: {
+    options = {
+      enable = lib.mkEnableOption "Enable prometheus module";
+
+      primaryNode = lib.mkOption {
+        type = types.submodule primaryNodeOpts;
+      };
+
+      wireguardPort = lib.mkOption {
+        type = types.int;
+        default = 12913;
+      };
+
+      wireguardListenOn = lib.mkOption {
+        type = types.str;
+        # default = config.nodes.${options.primaryNode}.networking.public.ipv6;
+        description = "What to listen on in regards to Wireguard";
+      };
+
+      nodes = lib.mkOption {
+        default = {};
+        type = types.attrsOf (types.submodule nodeOpts);
+      };
+    };
+  };
+in {
+  imports = [
+    ./wireguard.nix
+    ./prometheus.nix
+  ];
+
+  options.prometheus = lib.mkOption {
+    type = types.submodule baseOpts;
+    default = {};
+  };
+}

--- a/modules/prometheus/default.nix
+++ b/modules/prometheus/default.nix
@@ -89,11 +89,13 @@ let
         type = types.attrsOf (types.submodule nodeOpts);
         default = {};
         apply = x: let
-            nodesFilteredPrimary = lib.attrValues (lib.filterAttrs (_: v: v.isPrimary) x);
+            # only use enabledNodes
+            enabledNodes = lib.filterAttrs (_: v: v.enable ) x;
+            nodesFilteredPrimary = lib.attrValues (lib.filterAttrs (_: v: v.isPrimary) enabledNodes);
             primaryNode = builtins.elemAt nodesFilteredPrimary 0;
           in if builtins.length nodesFilteredPrimary == 0
                 then throw "there needs to be at least one primary node"
-                else x // { "${primaryNode.name}" = primaryNode // { isLocal = true; }; };
+                else enabledNodes // { "${primaryNode.name}" = primaryNode // { isLocal = true; }; };
       };
     };
   };

--- a/modules/prometheus/prometheus.nix
+++ b/modules/prometheus/prometheus.nix
@@ -1,0 +1,111 @@
+{ config, nodes, lib, ... }:
+
+let
+  ## configs
+  primaryNode = "srtoffee";
+  defaultInterval = "30s";
+  wgSystemdServiceName = "wireguard-wgprom.service";
+
+  # TODO(eyJhb): make this more pretty
+  nodes = lib.mapAttrsToList (_: v: v) config.prometheus.nodes;
+  nodesNoPrimary = builtins.filter (node: node.name != primaryNode) nodes;
+
+  ## functions
+  mkNodeConfig = node: exporters: { config, ...}: {
+    services.prometheus.exporters = mkExporters node exporters;
+
+    # systemd, Requires= After=
+    systemd.services = let
+      configs = builtins.listToAttrs (lib.forEach exporters (exp: {
+        name = "prometheus-${exp.name}-exporter";
+        value = {
+          requires = [ wgSystemdServiceName ];
+          after = [ wgSystemdServiceName ];
+          serviceConfig.RestartSec = "1s";
+        };
+      }));
+    in if node.isLocal then {} else configs;
+  };
+
+  mkExporters = node: exporters: builtins.listToAttrs (
+    lib.forEach exporters (exp: {
+      name = exp.name;
+      value = {
+        enable = true;
+        # TODO(eyJhb): here we just assume everything is IPv6
+        # unless this works for IPv4 as well?
+        listenAddress = "${node.ip}";
+      } // exp.options;
+    })
+  );
+
+  # create batches of nodes
+  mkScrapeConfig = jobName: nodes: port: interval: {
+    job_name = jobName;
+    scrape_interval = interval;
+
+    static_configs = let
+      # do something with the nodes
+      configs = lib.forEach nodes (node: {
+        targets = [ "${node.ip}:${toString port}@${node.name}" ];
+        # labels.alias = x.name;
+      });
+    in configs;
+
+    relabel_configs = [
+      {
+        source_labels = [ "__address__" ];
+        regex = ".*@(.*)";
+        target_label = "instance";
+      }
+      {
+        source_labels = [ "__address__" ];
+        regex = "(.*)@.*";
+        target_label = "__address__";
+      }
+    ];
+  };
+
+  # exporters to use
+  exporters = [
+    # node exporter
+    {
+      name = "node";
+      port = 9100;
+      interval = "10s";
+      options = {
+        enabledCollectors = [
+          # extra high (that we should enable)
+          "systemd"
+          "logind"
+          "ethtool"
+        ];
+      };
+    }
+
+    # others??
+  ];
+
+in {
+  nodes = lib.recursiveUpdate {
+    # primary node settings
+    "${primaryNode}".configuration = { config, ... }: {
+
+      # prometheus
+      services.prometheus = {
+        enable = true;
+        scrapeConfigs = lib.forEach exporters (exp:
+          mkScrapeConfig exp.name nodes exp.port defaultInterval
+        );
+
+        exporters = let
+          filteredNodes = builtins.filter (node: node.name == primaryNode) nodes;
+          val = if (builtins.length filteredNodes) > 0
+            then mkExporters (builtins.elemAt filteredNodes 0) exporters
+            else {};
+        in val;
+      };
+    };
+
+  } (lib.listToAttrs (lib.forEach nodesNoPrimary (node: lib.nameValuePair node.name { configuration = (mkNodeConfig node exporters); } )));
+}

--- a/modules/prometheus/utils.nix
+++ b/modules/prometheus/utils.nix
@@ -1,0 +1,14 @@
+{ lib, ... }:
+
+rec {
+  isIPv6 = str: if (builtins.match "([0-9]+)\\.([0-9]+)\\.([0-9]+)\\.([0-9]+)" str) == null then true else false;
+
+  # adds the correct subnet for either IPv6 or IPv4
+  makeIPSubnet = str: if isIPv6 str
+                      then "${str}/128"
+                      else "${str}/32";
+
+  wrapIP = str: if isIPv6 str
+                    then "[${str}]"
+                    else str;
+}

--- a/modules/prometheus/wireguard.nix
+++ b/modules/prometheus/wireguard.nix
@@ -1,0 +1,89 @@
+{ config, nodes, lib, ... }:
+
+let
+  primaryNode = config.prometheus.primaryNode;
+  wireguardPort = config.prometheus.wireguardPort;
+  endpoint = "${config.prometheus.wireguardListenOn}:${toString config.prometheus.wireguardPort}";
+
+  # all the nodes that should connect using wireguard
+  nodes = builtins.filter (node: node.isLocal == false) (lib.mapAttrsToList (_: v: v) config.prometheus.nodes);
+  
+  # helpers
+  mkWireguardPeer = {
+      publicKey
+    , allowedIPs
+    , presharedKeyFile ? null
+    }: (
+      {
+        allowedIPs = allowedIPs;
+        publicKey = publicKey;
+        # add presharedkey if specified
+      } // (if presharedKeyFile != null then { presharedKeyFile = presharedKeyFile; } else {})
+  );
+
+  # just a little shorthand for making secrets easier, doesn't really
+  # add much "easy" to it, as we have a lot of helper functions
+  mkSecrets = secrets: lib.mapAttrs (n: v: { file = v; }) secrets;
+
+  mkPeerConfig = node: { config, ... }: {
+      # secrets
+      secrets.files = mkSecrets {
+        "wg-${node.name}-privatekey" = node.wgPrivateKey;
+        "wg-${node.name}-preshared" = node.wgPresharedKey;
+      };
+
+      networking.wireguard = {
+        enable = true;
+
+        interfaces.wgprom = {
+          ips = [ node.ips ];
+
+          privateKeyFile = "${toString config.secrets.files."wg-${node.name}-privatekey".file}";
+
+          peers = [
+            {
+              allowedIPs = [ primaryNode.ip ];
+              endpoint = endpoint;
+              persistentKeepalive = 25;
+              publicKey = lib.strings.fileContents primaryNode.wgPublicKey;
+              presharedKeyFile = "${toString config.secrets.files."wg-${node.name}-preshared".file}";
+            }
+          ];
+        };
+      };
+    };
+in {
+  nodes = {
+    # server config
+    "${primaryNode.name}".configuration = { config, ... }: {
+      # make secrets
+      secrets.files = mkSecrets (
+        (builtins.listToAttrs (
+          lib.forEach nodes (node: { name = "wg-${node.name}-preshared"; value = node.wgPresharedKey; })
+        )) // {
+          "wg-${primaryNode.name}-privatekey" = primaryNode.wgPrivateKey;
+        }
+      );
+
+      networking.wireguard = {
+        enable = true;
+
+        interfaces.wgprom = {
+          ips = [ primaryNode.ip ];
+          privateKeyFile = "${toString config.secrets.files."wg-${primaryNode.name}-privatekey".file}";
+          listenPort = wireguardPort;
+
+          # add all our peers from nodes
+          peers = let
+            peerConfigs = lib.forEach nodes (node: mkWireguardPeer {
+              allowedIPs = [ node.ips ];
+              publicKey = lib.strings.fileContents node.wgPublicKey;
+              presharedKeyFile = "${toString config.secrets.files."wg-${node.name}-preshared".file}";
+            });
+          in peerConfigs;
+        };
+      };
+    };
+    # peer configs
+  } // (lib.listToAttrs (lib.forEach nodes (node: lib.nameValuePair node.name { configuration = (mkPeerConfig node); } )));
+}


### PR DESCRIPTION
This is still WIP, but currently it does the following

- Starts a prometheus+wireguard instance on the primary node
- Connect using Wireguard to the primary node, if not in the local network
- Expose node_exporter to the Wireguard interface
- Primary node will scrape nodes on an interval using the Wireguard tunnel (if needed)

# TODO

- [x] Make the enabled exporters configurable
- [ ] Automatically assign IPs without user needing to specify them
- [x] Do not start wireguard server, if all nodes are local