### PR TITLE
nixus.zfs-snap: ZFS snapshots before switching configuration (+cleanup)

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -28,6 +28,7 @@ nixusArgs: conf: let
       modules/public-ip.nix
       modules/dns.nix
       modules/vpn
+      modules/zfs-snap.nix
       conf
       # Not naming it pkgs to avoid confusion and trouble for overriding scopes
       {

--- a/modules/zfs-snap.nix
+++ b/modules/zfs-snap.nix
@@ -12,19 +12,31 @@ let
     # run snaps for all the defined pools
   '' + (lib.concatMapStringsSep "\n" (x: "echo Taking snapshot for ${x} && zfs snapshot ${x}@$tag") pools));
 
-  mkScriptCleanup = prefix: pools: retention: nixus.pkgs.writeShellScript "deploy-zfs-snap-cleanup" (lib.concatMapStringsSep "\n" (x: "echo Deleting snapshots for ${x} && zfs list -t snapshot ${x} -o name | tail -n +2 | grep -i '${prefix}' | sort | head -n -${toString retention} | xargs -L 1 --no-run-if-empty zfs destroy") pools);
+  mkScriptCleanup = prefix: pools: retention: nixus.pkgs.writeShellScript "deploy-zfs-snap-cleanup" (lib.concatMapStringsSep "\n" (x: ''
+    echo Deleting snapshots for ${x} && \
+    zfs list -t snapshot -o name ${x} | \
+    tail -n +2 | \
+    grep '${prefix}' | \
+    sort | \
+    head -n -${toString retention} | \
+    xargs -L 1 --no-run-if-empty zfs destroy
+  '') pools);
 
   nodeOpts = {
     options = {
       pools = lib.mkOption {
         type = types.listOf types.str;
         default = [];
-        description = "List of pools to make snapshots for, ie. rpool/safe/persistent";
+        description = "List of pools to make snapshots for";
       };
       retention = lib.mkOption {
         type = types.int;
         default = 30;
-        description = "How many previous ZFS snapshots to keep";
+        description = ''
+          How many previous snapshots to keep.
+          If set to zero, then all snapshots will be deleted upon successful switch.
+          If less than zero, the cleanup script will never run.
+        '';
       };
     };
   };
@@ -50,33 +62,51 @@ in {
       type = types.submodule baseOpts;
       default = {};
       description = ''
-        Used to make ZFS snapshots on host, before deploying and switching to configuration.
-        Cleanup is also done, where a specified number of previous snapshot can be keept, before they are removed.
+        Used to make ZFS snapshots on nodes, before deploying and switching to configuration.
+        Cleanup is done after a successfull switch, where a specified number of previous snapshot will be keept using the retention number.
       '';
+      example = {
+        nodes = {
+          srtoffee = {
+            pools = [
+              "rpool/safe/persistent"
+              "rpool/safe/user"
+            ];
+            retention = 30;
+          };
+        };
+        prefix = "nixus-snapshots-";
+      };
     };
   };
 
   config.nodes = let
     nnodes = lib.mapAttrs (_: v: {
-      deployScriptPhases.zfs-snap-create = let
-        script = mkScriptCreate config.zfs-snap.prefix v.pools;
-      in lib.dag.entryBefore ["switch"] ''
-        echo Copying ZFS snapshotting create script
-        nix-copy-closure --to "$HOST" ${script}
-        echo Taking ZFS snapshots
-        ssh "$HOST" ${script}
-        echo Finished taking snapshots
-      '';
+      deployScriptPhases = let
+        scriptCreate = mkScriptCreate config.zfs-snap.prefix v.pools;
+        scriptCleanup = mkScriptCleanup config.zfs-snap.prefix v.pools v.retention;
+        fullScriptCreate = ''
+          echo Copying ZFS snapshotting create script
+          nix-copy-closure --to "$HOST" ${scriptCreate}
+          echo Taking ZFS snapshots
+          ssh "$HOST" ${scriptCreate}
+          echo Finished taking snapshots
+        '';
 
-      deployScriptPhases.zfs-snap-cleanup = let
-        script = mkScriptCleanup config.zfs-snap.prefix v.pools v.retention;
-      in lib.dag.entryAfter ["switch"] ''
-        echo Copying ZFS snapshotting cleanup script
-        nix-copy-closure --to "$HOST" ${script}
-        echo Cleaning ZFS snapshots
-        ssh "$HOST" ${script}
-        echo Finished cleaning snapshots
-      '';
+        fullScriptCleanup = ''
+          echo Copying ZFS snapshotting cleanup script
+          nix-copy-closure --to "$HOST" ${scriptCleanup}
+          echo Cleaning ZFS snapshots
+          ssh "$HOST" ${scriptCleanup}
+          echo Finished cleaning snapshots
+        '';
+
+      in {
+        zfs-snap-create = lib.dag.entryBefore ["switch"] fullScriptCreate;
+      } // (if (v.retention >= 0)
+            then { zfs-snap-cleanup = lib.dag.entryAfter ["switch"] fullScriptCleanup; }
+            else {}
+      );
     }) config.zfs-snap.nodes;
   in nnodes;
 }

--- a/modules/zfs-snap.nix
+++ b/modules/zfs-snap.nix
@@ -1,0 +1,82 @@
+{ config, lib, nixus, ... }:
+
+let
+  inherit (lib) types;
+
+  mkScriptCreate = prefix: pools: nixus.pkgs.writeShellScript "deploy-zfs-snap-create" (''
+    # get current nixos generation number
+    id=$(readlink /nix/var/nix/profiles/system | sed 's/system-\(.*\)-link/\1/')
+    # format for the tags, adding a date so there can be multiple for a id
+    tag="${prefix}$(date +%Y%m%d%H%M%S)-$id"
+
+    # run snaps for all the defined pools
+  '' + (lib.concatMapStringsSep "\n" (x: "echo Taking snapshot for ${x} && zfs snapshot ${x}@$tag") pools));
+
+  mkScriptCleanup = prefix: pools: retention: nixus.pkgs.writeShellScript "deploy-zfs-snap-cleanup" (lib.concatMapStringsSep "\n" (x: "echo Deleting snapshots for ${x} && zfs list -t snapshot ${x} -o name | tail -n +2 | grep -i '${prefix}' | sort | head -n -${toString retention} | xargs -L 1 --no-run-if-empty zfs destroy") pools);
+
+  nodeOpts = {
+    options = {
+      pools = lib.mkOption {
+        type = types.listOf types.str;
+        default = [];
+        description = "List of pools to make snapshots for, ie. rpool/safe/persistent";
+      };
+      retention = lib.mkOption {
+        type = types.int;
+        default = 30;
+        description = "How many previous ZFS snapshots to keep";
+      };
+    };
+  };
+
+  baseOpts = {
+    options = {
+      nodes = lib.mkOption {
+        type = types.attrsOf (types.submodule nodeOpts);
+        default = {};
+        description = "Nodes to enable snapshotting for";
+      };
+
+      prefix = lib.mkOption {
+        type = types.str;
+        default = "nixus-snap-";
+        description = "Prefix to use for snapshots";
+      };
+    };
+  };
+in {
+  options = {
+    zfs-snap = lib.mkOption {
+      type = types.submodule baseOpts;
+      default = {};
+      description = ''
+        Used to make ZFS snapshots on host, before deploying and switching to configuration.
+        Cleanup is also done, where a specified number of previous snapshot can be keept, before they are removed.
+      '';
+    };
+  };
+
+  config.nodes = let
+    nnodes = lib.mapAttrs (_: v: {
+      deployScriptPhases.zfs-snap-create = let
+        script = mkScriptCreate config.zfs-snap.prefix v.pools;
+      in lib.dag.entryBefore ["switch"] ''
+        echo Copying ZFS snapshotting create script
+        nix-copy-closure --to "$HOST" ${script}
+        echo Taking ZFS snapshots
+        ssh "$HOST" ${script}
+        echo Finished taking snapshots
+      '';
+
+      deployScriptPhases.zfs-snap-cleanup = let
+        script = mkScriptCleanup config.zfs-snap.prefix v.pools v.retention;
+      in lib.dag.entryAfter ["switch"] ''
+        echo Copying ZFS snapshotting cleanup script
+        nix-copy-closure --to "$HOST" ${script}
+        echo Cleaning ZFS snapshots
+        ssh "$HOST" ${script}
+        echo Finished cleaning snapshots
+      '';
+    }) config.zfs-snap.nodes;
+  in nnodes;
+}


### PR DESCRIPTION
This module adds support for making a ZFS snapshot on the node that is to be deployed to, before the configuration is switched.
This is nice in cases such as Nexcloud, which will run a migration when switching and if it fails you can no longer switch back to the previous version.

There is also the option of doing cleanup of the previous snapshots, which will by default keep the last 30 snapshots.
If this is set to 0, it will delete the snapshots right after a successful switch.
If set to a negative number ie. -1, it will keep them forever, and an external tool might be run to delete them on a interval.

To allow non-root users to create snapshots `zfs allow nix-deployer snapshot rpool/safe/persistent` should be used.
I do not like allowing the same user to delete snapshots, as it includes snapshots not made by nixus as well, and would rather use an external program to handle this for me.