### PR TITLE
bumped nixpkgs

### DIFF
--- a/nixpkgs.nix
+++ b/nixpkgs.nix
@@ -1,4 +1,4 @@
 fetchTarball {
-  url = "https://github.com/NixOS/nixpkgs/tarball/81cef6b70fb5d5cdba5a0fef3f714c2dadaf0d6d";
-  sha256 = "1mj9psy1hfy3fbalwkdlyw3jmc97sl9g3xj1xh8dmhl68g0pfjin";
+  url = "https://github.com/NixOS/nixpkgs/tarball/9ddd6d7266f287eb6a2cd0d3c1797e2708f621b2";
+  sha256 = "sha256:1ilrny7drvv0fdibnlm1lpg5il5g651kla9xys4kqypk28xpyx1g";
 }


### PR DESCRIPTION
Commit https://github.com/NixOS/nixpkgs/commit/df590070b007b2cd2f64647b2780c903506aa21f adds an additional type, and without this nixus breaks with the change.

```
installing
error: attribute 'singleLineStr' missing
       at /nix/store/g4pv0kxp4rf7sqd4jm3g1hc03blfvj5s-pkgs-unstable-patched/nixos/modules/services/networking/ssh/sshd.nix:33:29:
           32|       keys = mkOption {
           33|         type = types.listOf types.singleLineStr;
             |                             ^
           34|         default = [];
(use '--show-trace' to show detailed location information)
```