### PR TITLE
Update nixpkgs

### DIFF
--- a/nixpkgs.nix
+++ b/nixpkgs.nix
@@ -1,4 +1,4 @@
 fetchTarball {
-  url = "https://github.com/NixOS/nixpkgs/tarball/819e4d63fc7f337a822a049fd055cd7615a5e0d6";
-  sha256 = "sha256:05m6gfxmbhwq9kp5kpgq437mbm22l241zjqmmynrackpbdjazczq";
+  url = "https://github.com/NixOS/nixpkgs/tarball/168d1c578909dc143ba52dbed661c36e76b12b36";
+  sha256 = "sha256:0iyasn0phr05dh4rwam2draprinh3db5dk83bg48v166v7bhq5qw";
 }


### PR DESCRIPTION
This seems to fix: `error: attribute 'passwdEntry' missing` since https://github.com/NixOS/nixpkgs/pull/179002

I just picked the latest nixos-unstable, is that right?