### PR TITLE
Update nixpkgs

### DIFF
--- a/nixpkgs.nix
+++ b/nixpkgs.nix
@@ -1,4 +1,4 @@
 fetchTarball {
-  url = "https://github.com/NixOS/nixpkgs/tarball/b39fd6e4edef83cb4a135ebef98751ce23becc33";
-  sha256 = "sha256:030h84xxq1dp9m51ir05rvjnray7fxpq9g93vxxykp45vm9bm2k2";
+  url = "https://github.com/NixOS/nixpkgs/tarball/a518c77148585023ff56022f09c4b2c418a51ef5";
+  sha256 = "sha256:0rr6qp2zk1yp3z1sz3zxm1gmqpyy0vnbxs14qgpq9m6977ngjgm3";
 }


### PR DESCRIPTION
```
unpacking 'https://github.com/Infinisil/nixus/archive/5b083f5e9c3a754f8f422f1b09401a707f01b23d.tar.gz'...
unpacking 'https://github.com/NixOS/nixpkgs/tarball/b39fd6e4edef83cb4a135ebef98751ce23becc33'...
error: undefined variable 'mkAliasOptionModuleMD' at /home/runner/work/nixconfig/nixconfig/nix/nixos-unstable/nixos/modules/config/users-groups.nix:447:6
(use '--show-trace' to show detailed location information)
Error: Process completed with exit code 1.
```