### PR TITLE
bumped nixpkgs version

### DIFF
--- a/nixpkgs.nix
+++ b/nixpkgs.nix
@@ -1,4 +1,4 @@
 fetchTarball {
-  url = "https://github.com/NixOS/nixpkgs/tarball/545c7a31e5dedea4a6d372712a18e00ce097d462";
-  sha256 = "sha256:1dbsi2ccq8x0hyl8n0hisigj8q19amvj9irzfbgy4b3szb6x2y6l";
+  url = "https://github.com/NixOS/nixpkgs/tarball/f91ee3065de91a3531329a674a45ddcb3467a650";
+  sha256 = "sha256:1jgcgllp8pxjz3q6r2yswsvlg96wlcnvdpgi71k7inibffqhq0z9";
 }


### PR DESCRIPTION
Fixes 

```
eyjhb@jhbws01 ~/c/nixos-systems (master) [1]> nix-build                                                                    niv 
error: attribute 'pkgs' missing

       at /nix/store/68njk90djlnf7xcm06am4pp2q2v33m3y-nixpkgs-src/nixos/modules/misc/nixpkgs.nix:52:14:

           51|
           52|   pkgsType = types.pkgs // {
             |              ^
           53|     # This type is only used by itself, so let's elaborate the description a bit
(use '--show-trace' to show detailed location information)
```

On nixos-unstable