### PR TITLE
bump nixpkgs - fixes lib.match errors

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1714184256,
-        "narHash": "sha256-/VyiyGD2q6qN/uAvotKxXuQJWLlmSckAdf7S8jj4Q5c=",
+        "lastModified": 1721497942,
+        "narHash": "sha256-EDPL9qJfklXoowl3nEBmjDIqcvXKUZInt5n6CCc1Hn4=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "698fd43e541a6b8685ed408aaf7a63561018f9f8",
+        "rev": "d43f0636fc9492e83be8bbb41f9595d7a87106b8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Got the following error when trying to build with nixus.

```
> nix-build -A chronos
error:
       … while calling the 'derivationStrict' builtin

         at /builtin/derivation.nix:9:12: (source not available)

       … while evaluating derivation 'deploy'
         whose name attribute is located at /nix/store/v3nvbfwwnd3cwcjkjwd76ml0kdvvf6f9-source/pkgs/stdenv/generic/make-derivation.nix:331:7

       … while evaluating attribute 'text' of derivation 'deploy'

         at /nix/store/v3nvbfwwnd3cwcjkjwd76ml0kdvvf6f9-source/pkgs/build-support/trivial-builders/default.nix:103:16:

          102|       ({
          103|         inherit text executable checkPhase allowSubstitutes preferLocalBuild;
             |                ^
          104|         passAsFile = [ "text" ]

       (stack trace truncated; use '--show-trace' to show the full trace)

       error: attribute 'match' missing

       at /nix/store/y7l7n6pv90lks34pjnawc372c8m5dxag-nixpkgs-src/nixos/modules/config/users-groups.nix:3:4:

            2|
            3| let
             |    ^
            4|   inherit (lib)
       Did you mean path?
```

This bump should fix it :)