### PR TITLE
bump nixpkgs - fixes lib.meta.defaultPriority missing

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -5,11 +5,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1694529238,
-        "narHash": "sha256-zsNZZGTGnMOf9YpHKJqMSsa0dXbfmxeoJ7xHlrt+xmY=",
+        "lastModified": 1710146030,
+        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "ff7b65b44d01cf9ba6a71320833626af21126384",
+        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
         "type": "github"
       },
       "original": {
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1695318763,
-        "narHash": "sha256-FHVPDRP2AfvsxAdc+AsgFJevMz5VBmnZglFUMlxBkcY=",
+        "lastModified": 1726042813,
+        "narHash": "sha256-LnNKCCxnwgF+575y0pxUdlGZBO/ru1CtGHIqQVfvjlA=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "e12483116b3b51a185a33a272bf351e357ba9a99",
+        "rev": "159be5db480d1df880a0135ca0bfed84c2f88353",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Fixes 

```
error:
       … while calling the 'derivationStrict' builtin

         at /builtin/derivation.nix:9:12: (source not available)

       … while evaluating derivation 'deploy'
         whose name attribute is located at /nix/store/d3raxzxl79hz2k0d8di8lma931dgd1ny-source/pkgs/stdenv/generic/make-deri…

       … while evaluating attribute 'text' of derivation 'deploy'

         at /nix/store/d3raxzxl79hz2k0d8di8lma931dgd1ny-source/pkgs/build-support/trivial-builders/default.nix:103:16:

          102|       ({
          103|         inherit text executable checkPhase allowSubstitutes preferLocalBuild;
             |                ^
          104|         passAsFile = [ "text" ]

       (stack trace truncated; use '--show-trace' to show the full trace)

       error: attribute 'defaultPriority' missing

       at /nix/store/1ayx5hs41z31jw5j1xdg4nb78advz313-nixpkgs-src/nixos/modules/config/system-path.nix:6:67:

            5|
            6|   requiredPackages = map (pkg: lib.setPrio ((pkg.meta.priority or lib.meta.defaultPriority) + 3) pkg)
             |                                                                   ^
            7|     [ pkgs.acl
```