### PR TITLE
attempt to fix version mismatch of pkgs.lib and lib

### DIFF
--- a/modules/options.nix
+++ b/modules/options.nix
@@ -62,6 +62,7 @@ let
             };
             evalConfig = import (config.nixpkgs + "/nixos/lib/eval-config.nix") {
               system = nixus.pkgs.system;
+              specialArgs.lib = nixus.extendLib (import (config.nixpkgs + "/lib"));
               modules = [
                 extraConfig
                 {
@@ -71,7 +72,6 @@ let
                   };
                 }
               ];
-              lib = nixus.extendLib (import (config.nixpkgs + "/lib"));
             };
           in evalConfig.type or legacy;
         default = {};


### PR DESCRIPTION
This should fix https://github.com/infinisil/nixus/issues/62 as well as fix https://github.com/infinisil/nixus/pull/61, and generally make so we do not have to bump nixpkgs all the time.